### PR TITLE
fix: update file ext on script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ make test
 ## Getting started with your own extension
 After creating a repository from this template, the first step is to name your extension. To rename the extension, run:
 ```
-./scripts/set_extension_name.sh <extension_name_you_want>
+python3 ./scripts/set_extension_name.py <extension_name_you_want>
 ```
 Feel free to delete the script after this step.
 
@@ -67,11 +67,11 @@ Easy distribution of extensions built with this template is facilitated using a 
 
 This step requires that you pass the following 4 parameters to your github repo as action secrets:
 
-secret name | description
---- | ---
-S3_REGION | s3 region holding your bucket
-S3_BUCKET | the name of the bucket to deploy to
-S3_DEPLOY_ID | the S3 key id
-S3_DEPLOY_KEY | the S3 key secret
+| -secret name   | description                         |
+| -------------- | ----------------------------------- |
+| -S3_REGION     | s3 region holding your bucket       |
+| -S3_BUCKET     | the name of the bucket to deploy to |
+| -S3_DEPLOY_ID  | the S3 key id                       |
+| -S3_DEPLOY_KEY | the S3 key secret                   |
 
 After setting these variables, all pushes to master will trigger a new (dev) release.

--- a/scripts/set_extension_name.py
+++ b/scripts/set_extension_name.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import sys, os
 from pathlib import Path
@@ -36,8 +36,8 @@ replace("./Makefile", string_to_find.upper(), string_to_replace.upper())
 replace("./README.md", string_to_find, string_to_replace)
 
 # rename files
-os.rename(f'test/python/{string_to_find}_test.py',f'test/python/{string_to_replace}_test.py')
-os.rename(f'test/sql/{string_to_find}.test',f'test/sql/{string_to_replace}.test')
-os.rename(f'src/{string_to_find}_extension.cpp',f'src/{string_to_replace}_extension.cpp')
-os.rename(f'src/include/{string_to_find}_extension.hpp',f'src/include/{string_to_replace}_extension.hpp')
-os.rename(f'test/nodejs/{string_to_find}_test.js',f'test/nodejs/{string_to_replace}_test.js')
+os.rename(f'test/python/{string_to_find}_test.py', f'test/python/{string_to_replace}_test.py')
+os.rename(f'test/sql/{string_to_find}.test', f'test/sql/{string_to_replace}.test')
+os.rename(f'src/{string_to_find}_extension.cpp', f'src/{string_to_replace}_extension.cpp')
+os.rename(f'src/include/{string_to_find}_extension.hpp', f'src/include/{string_to_replace}_extension.hpp')
+os.rename(f'test/nodejs/{string_to_find}_test.js', f'test/nodejs/{string_to_replace}_test.js')


### PR DESCRIPTION
I have a couple extensions I've been developing, so decided to "onboard" them to this. It worked great after getting it to start, though there were a couple of hiccups that this PR addresses. One suggestion might be a regex in the script to check the name is ok... I had a false start due to a name that had a hyphen.

Also, the markdown table was also updated by my markdown formatter on accident, happy to revert.

Thanks for making this, I'm excited what you'all are doing w/ extensions as a user/developer.