### PR TITLE
Update to DuckDB v0.8.0

### DIFF
--- a/.github/workflows/ExtensionTemplate.yml
+++ b/.github/workflows/ExtensionTemplate.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Rename extension
         run: |
-          python3 scripts/set_extension_name.py testext
+          python3 scripts/set_extension_name.py testext testext
 
       - name: Build
         run: |
@@ -103,7 +103,7 @@ jobs:
 
       - name: Rename extension
         run: |
-          python scripts/set_extension_name.py testext
+          python scripts/set_extension_name.py testext testext
 
       - name: Build
         run: |
@@ -144,7 +144,7 @@ jobs:
 
       - name: Rename extension
         run: |
-          python scripts/set_extension_name.py testext
+          python scripts/set_extension_name.py testext testext
 
       - name: Build
         run: |

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -12,33 +12,36 @@ defaults:
     shell: bash
 
 jobs:
-  python:
-    name: Python
-    runs-on: ubuntu-latest
-    env:
-      GEN: ninja
-
-    steps:
-      - name: Install Ninja
-        run: |
-          sudo apt-get update -y -qq
-          sudo apt-get install -y -qq ninja-build
-
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: 'true'
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-
-      - name: Build DuckDB Python client
-        run: make debug_python
-
-      - name: Install Python test dependencies
-        run: python -m pip install --upgrade pytest
-
-      - name: Run Python client tests
-        run: |
-          make test_debug_python
+# TODO: python inlined builds broken currently broken, to run your extension from python,
+#       use regular build to build the loadable extensions, then directly load extension binary from
+#       desired duckdb client
+#  python:
+#    name: Python
+#    runs-on: ubuntu-latest
+#    env:
+#      GEN: ninja
+#
+#    steps:
+#      - name: Install Ninja
+#        run: |
+#          sudo apt-get update -y -qq
+#          sudo apt-get install -y -qq ninja-build
+#
+#      - uses: actions/checkout@v2
+#        with:
+#          fetch-depth: 0
+#          submodules: 'true'
+#
+#      - uses: actions/setup-python@v2
+#        with:
+#          python-version: '3.9'
+#
+#      - name: Build DuckDB Python client
+#        run: make debug_python
+#
+#      - name: Install Python test dependencies
+#        run: python -m pip install --upgrade pytest
+#
+#      - name: Run Python client tests
+#        run: |
+#          make test_debug_python

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -12,36 +12,38 @@ defaults:
     shell: bash
 
 jobs:
-# TODO: python inlined builds broken currently broken, to run your extension from python,
-#       use regular build to build the loadable extensions, then directly load extension binary from
-#       desired duckdb client
-#  python:
-#    name: Python
-#    runs-on: ubuntu-latest
-#    env:
-#      GEN: ninja
-#
-#    steps:
-#      - name: Install Ninja
-#        run: |
-#          sudo apt-get update -y -qq
-#          sudo apt-get install -y -qq ninja-build
-#
-#      - uses: actions/checkout@v2
-#        with:
-#          fetch-depth: 0
-#          submodules: 'true'
-#
-#      - uses: actions/setup-python@v2
-#        with:
-#          python-version: '3.9'
-#
-#      - name: Build DuckDB Python client
-#        run: make debug_python
-#
-#      - name: Install Python test dependencies
-#        run: python -m pip install --upgrade pytest
-#
-#      - name: Run Python client tests
-#        run: |
-#          make test_debug_python
+
+  python:
+    # TODO: python inlined builds broken currently broken, to run your extension from python,
+    #       use regular build to build the loadable extensions, then directly load extension binary from
+    #       desired duckdb client
+    if: false
+    name: Python
+    runs-on: ubuntu-latest
+    env:
+      GEN: ninja
+
+    steps:
+      - name: Install Ninja
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq ninja-build
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Build DuckDB Python client
+        run: make debug_python
+
+      - name: Install Python test dependencies
+        run: python -m pip install --upgrade pytest
+
+      - name: Run Python client tests
+        run: |
+          make test_debug_python


### PR DESCRIPTION
Update the template to v0.8.0. There's an issue which currently prevents the Python inlined builds to fail. I disabled them for now as this requires a fix in duckdb which I will PR. Then we can re-enable it with the next duckdb release as thats fixed. 

Note that this only means that python builds with the extension inlined are broken, you can still build the loadable extension and `LOAD <your extension>` from an v0.8.0 client