### PR TITLE
Remove ExtensionTemplate.yml in template repos

### DIFF
--- a/.github/workflows/ExtensionTemplate.yml
+++ b/.github/workflows/ExtensionTemplate.yml
@@ -1,5 +1,6 @@
 #
-# NOTE: this workflow is for testing the extension template itself, this workflow should be removed in your extension
+# NOTE: this workflow is for testing the extension template itself,
+#     this workflow will be removed when scripts/set_extension_name.py is run
 #
 
 name: Extension Template

--- a/scripts/set_extension_name.py
+++ b/scripts/set_extension_name.py
@@ -51,3 +51,6 @@ os.rename(f'test/sql/{string_to_find}.test', f'test/sql/{string_to_replace}.test
 os.rename(f'src/{string_to_find}_extension.cpp', f'src/{string_to_replace}_extension.cpp')
 os.rename(f'src/include/{string_to_find}_extension.hpp', f'src/include/{string_to_replace}_extension.hpp')
 os.rename(f'test/nodejs/{string_to_find}_test.js', f'test/nodejs/{string_to_replace}_test.js')
+
+# remove template-specific files
+os.remove('.github/workflows/ExtensionTemplate.yml')


### PR DESCRIPTION
This workflows isn't needed in templates.
It can be removed when running the set_extension_name.py script.