### PR TITLE
fix for issue #38 rename is broken

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ make test
 ## Getting started with your own extension
 After creating a repository from this template, the first step is to name your extension. To rename the extension, run:
 ```
-python3 ./scripts/set_extension_name.py <extension_name_you_want>
+python3 ./scripts/set_extension_name.py <name_for_extension> <name_for_function>
 ```
 Feel free to delete the script after this step.
 

--- a/scripts/set_extension_name.py
+++ b/scripts/set_extension_name.py
@@ -34,13 +34,14 @@ files_to_search.extend(Path('./src').rglob('./*.md'))
 def replace_everywhere(to_find, to_replace):
     for path in files_to_search:
         replace(path, to_find, to_replace)
-        replace(path, to_find.capitalize(), to_replace.capitalize())
+        replace(path, to_find[0].upper() + to_find[1:], to_replace[0].upper() + to_replace[1:])
     
     replace("./CMakeLists.txt", to_find, to_replace)
     replace("./Makefile", to_find, to_replace)
-    replace("./Makefile", to_find.capitalize(), to_replace.capitalize())
+    replace("./Makefile", to_find[0].upper() + to_find[1:], to_replace[0].upper() + to_replace[1:])
     replace("./Makefile", to_find.upper(), to_replace.upper())
     replace("./README.md", to_find, to_replace)
+
 
 replace_everywhere("quack", name_function)
 replace_everywhere("<extension_name>", name_extension)

--- a/scripts/set_extension_name.py
+++ b/scripts/set_extension_name.py
@@ -11,6 +11,9 @@ if (len(sys.argv) != 3):
 name_extension = sys.argv[1]
 name_function = sys.argv[2]
 
+if ('_' in name_extension or name_extension[0].islower()):
+    raise Exception('Currently only extension names in CamelCase are allowed')
+
 def replace(file_name, to_find, to_replace):
     with open(file_name, 'r', encoding="utf8") as file :
         filedata = file.read()


### PR DESCRIPTION
this only a quick fix so other people wont waste too much time  recloneing and recompiling because the rename doesnt work. But probably the extension loader should be changed?

.capitalize() not only capitalizes the first letter but also sets all other letters to lowercase. 