### PR TITLE
fix rename script to properly handle snake case extensions

### DIFF
--- a/.github/workflows/ExtensionTemplate.yml
+++ b/.github/workflows/ExtensionTemplate.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Rename extension
         run: |
-          python3 scripts/set_extension_name.py testext testext
+          python3 scripts/set_extension_name.py ext_1_a_123b_b11
 
       - name: Build
         run: |
@@ -117,7 +117,7 @@ jobs:
 
       - name: Rename extension
         run: |
-          python scripts/set_extension_name.py testext testext
+          python scripts/set_extension_name.py ext_1_a_123b_b11
 
       - name: Build
         run: |
@@ -166,7 +166,7 @@ jobs:
 
       - name: Rename extension
         run: |
-          python scripts/set_extension_name.py testext testext
+          python scripts/set_extension_name.py ext_1_a_123b_b11
 
       - name: Build
         run: |

--- a/docs/NEXT_README.md
+++ b/docs/NEXT_README.md
@@ -1,10 +1,10 @@
-# <extension_name>
+# Quack
 
 This repository is based on https://github.com/duckdb/extension-template, check it out if you want to build and ship your own DuckDB extension.
 
 ---
 
-This extension, <extension_name>, allow you to ... <extension_goal>.
+This extension, Quack, allow you to ... <extension_goal>.
 
 
 ## Building
@@ -27,11 +27,11 @@ The main binaries that will be built are:
 ```sh
 ./build/release/duckdb
 ./build/release/test/unittest
-./build/release/extension/<extension_name>/<extension_name>.duckdb_extension
+./build/release/extension/quack/quack.duckdb_extension
 ```
 - `duckdb` is the binary for the duckdb shell with the extension code automatically loaded.
 - `unittest` is the test runner of duckdb. Again, the extension is already linked into the binary.
-- `<extension_name>.duckdb_extension` is the loadable binary as it would be distributed.
+- `quack.duckdb_extension` is the loadable binary as it would be distributed.
 
 ## Running the extension
 To run the extension code, simply start the shell with `./build/release/duckdb`.
@@ -82,6 +82,6 @@ DuckDB. To specify a specific version, you can pass the version instead.
 
 After running these steps, you can install and load your extension using the regular INSTALL/LOAD commands in DuckDB:
 ```sql
-INSTALL <extension_name>
-LOAD <extension_name>
+INSTALL quack
+LOAD quack
 ```

--- a/scripts/set_extension_name.py
+++ b/scripts/set_extension_name.py
@@ -1,15 +1,33 @@
 #!/usr/bin/python3
 
-import sys, os, shutil
+import sys, os, shutil, re
 from pathlib import Path
 
 shutil.copyfile(f'docs/NEXT_README.md', f'README.md')
 
-if (len(sys.argv) != 3):
-    raise Exception('usage: python3 set_extension_name.py <name_for_extension> <name_for_function>')
+if (len(sys.argv) != 2):
+    raise Exception('usage: python3 set_extension_name.py <name_for_extension_in_snake_case>')
 
 name_extension = sys.argv[1]
-name_function = sys.argv[2]
+
+def is_snake_case(s):
+    # Define the regex pattern for snake case with numbers
+    pattern = r'^[a-z0-9]+(_[a-z0-9]+)*$'
+
+    # Use re.match to check if the string matches the pattern
+    if re.match(pattern, s):
+        return True
+    else:
+        return False
+
+if name_extension[0].isdigit():
+    raise Exception('Please dont start your extension name with a number.')
+
+if not is_snake_case(name_extension):
+    raise Exception('Please enter the name of your extension in valid snake_case containing only lower case letters and numbers')
+
+def to_camel_case(snake_str):
+    return "".join(x.capitalize() for x in snake_str.lower().split("_"))
 
 def replace(file_name, to_find, to_replace):
     with open(file_name, 'r', encoding="utf8") as file :
@@ -31,18 +49,18 @@ files_to_search.extend(Path('./src').rglob('./*.md'))
 def replace_everywhere(to_find, to_replace):
     for path in files_to_search:
         replace(path, to_find, to_replace)
-        replace(path, to_find.capitalize(), to_replace.capitalize())
+        replace(path, to_find.capitalize(), to_camel_case(to_replace))
     
     replace("./CMakeLists.txt", to_find, to_replace)
     replace("./Makefile", to_find, to_replace)
-    replace("./Makefile", to_find.capitalize(), to_replace.capitalize())
+    replace("./Makefile", to_find.capitalize(), to_camel_case(to_replace))
     replace("./Makefile", to_find.upper(), to_replace.upper())
     replace("./README.md", to_find, to_replace)
 
-replace_everywhere("quack", name_function)
+replace_everywhere("quack", name_extension)
 replace_everywhere("<extension_name>", name_extension)
 
-string_to_replace = name_function
+string_to_replace = name_extension
 string_to_find = "quack"
 
 # rename files


### PR DESCRIPTION
fixes #38 
applies the ideas of https://github.com/duckdb/extension-template/pull/39

Should now properly handle extension names:
- only valid snake case allowed as input, no digits as first char.
- correctly produce camelcase for c++ classes
- updated the extension template CI to test this with a more tricky name 