### PR TITLE
Support streamlined paths for duckdb-wasm

### DIFF
--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -74,7 +74,10 @@ fi
 # upload versioned version
 if [[ $7 = 'true' ]]; then
   if [[ $4 == wasm* ]]; then
+    # Old style paths with additional duckdb-wasm
     aws s3 cp $ext.compressed s3://$5/duckdb-wasm/$1/$2/duckdb-wasm/$3/$4/$1.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
+    # New style paths for duckdb-wasm, more uniforms
+    aws s3 cp $ext.compressed s3://$5/$1/$2/$3/$4/$1.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
   else
     aws s3 cp $ext.compressed s3://$5/$1/$2/$3/$4/$1.duckdb_extension.gz --acl public-read
   fi
@@ -83,7 +86,10 @@ fi
 # upload to latest version
 if [[ $6 = 'true' ]]; then
   if [[ $4 == wasm* ]]; then
+    # Old style paths with additional duckdb-wasm
     aws s3 cp $ext.compressed s3://$5/duckdb-wasm/$3/$4/$1.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
+    # New style paths for duckdb-wasm, more uniforms
+    aws s3 cp $ext.compressed s3://$5/$3/$4/$1.duckdb_extension.wasm --acl public-read --content-encoding br --content-type="application/wasm"
   else
     aws s3 cp $ext.compressed s3://$5/$3/$4/$1.duckdb_extension.gz --acl public-read
   fi


### PR DESCRIPTION
As discussed here: https://github.com/duckdb/duckdb/pull/9883#issuecomment-1840137607

Move to more streamlined paths for duckdb-wasm in extension repositories.

Note that both standards will need to be around as long as publishing for v0.9.2 is supported (that is another few weeks).