### PR TITLE
chore: Inherit `.editorconfig` from duckdb submodule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,1 @@
+duckdb/.editorconfig


### PR DESCRIPTION
As symbolic link.