### PR TITLE
Add parallel build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ CLIENT_FLAGS=-DDUCKDB_EXTENSION_${EXTENSION_NAME}_SHOULD_LINK=1
 debug:
 	mkdir -p  build/debug && \
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(CLIENT_FLAGS) -DCMAKE_BUILD_TYPE=Debug -S ./duckdb/ -B build/debug && \
-	cmake --build build/debug --config Debug
+	cmake --build build/debug --config Debug -j 4
 
 release:
 	mkdir -p build/release && \


### PR DESCRIPTION
I've observed drastic improvement by adding -j <number> to cmake build.
I went from almost 40 min (using WSL 2) to less than 5min.