### PR TITLE
fix: make bootstrap check names earlier

### DIFF
--- a/.github/workflows/ExtensionTemplate.yml
+++ b/.github/workflows/ExtensionTemplate.yml
@@ -22,6 +22,7 @@ jobs:
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: 'x64-linux'
       GEN: ninja
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     defaults:
       run:
         shell: bash

--- a/scripts/bootstrap-template.py
+++ b/scripts/bootstrap-template.py
@@ -3,18 +3,10 @@
 import sys, os, shutil, re
 from pathlib import Path
 
-shutil.copyfile(f'docs/NEXT_README.md', f'README.md')
-os.remove(f'docs/NEXT_README.md')
-os.remove(f'docs/README.md')
-
-if (len(sys.argv) != 2):
-    raise Exception('usage: python3 bootstrap-template.py <name_for_extension_in_snake_case>')
-
-name_extension = sys.argv[1]
 
 def is_snake_case(s):
     # Define the regex pattern for snake case with numbers
-    pattern = r'^[a-z0-9]+(_[a-z0-9]+)*$'
+    pattern = r"^[a-z0-9]+(_[a-z0-9]+)*$"
 
     # Use re.match to check if the string matches the pattern
     if re.match(pattern, s):
@@ -22,36 +14,25 @@ def is_snake_case(s):
     else:
         return False
 
-if name_extension[0].isdigit():
-    raise Exception('Please dont start your extension name with a number.')
-
-if not is_snake_case(name_extension):
-    raise Exception('Please enter the name of your extension in valid snake_case containing only lower case letters and numbers')
 
 def to_camel_case(snake_str):
     return "".join(x.capitalize() for x in snake_str.lower().split("_"))
 
+
 def replace(file_name, to_find, to_replace):
-    with open(file_name, 'r', encoding="utf8") as file :
+    with open(file_name, "r", encoding="utf8") as file:
         filedata = file.read()
     filedata = filedata.replace(to_find, to_replace)
-    with open(file_name, 'w', encoding="utf8") as file:
+    with open(file_name, "w", encoding="utf8") as file:
         file.write(filedata)
 
-files_to_search = []
-files_to_search.extend(Path('./.github').rglob('./**/*.yml'))
-files_to_search.extend(Path('./test').rglob('./**/*.test'))
-files_to_search.extend(Path('./src').rglob('./**/*.hpp'))
-files_to_search.extend(Path('./src').rglob('./**/*.cpp'))
-files_to_search.extend(Path('./src').rglob('./**/*.txt'))
-files_to_search.extend(Path('./src').rglob('./*.md'))
 
 def replace_everywhere(to_find, to_replace):
     for path in files_to_search:
         replace(path, to_find, to_replace)
         replace(path, to_find.capitalize(), to_camel_case(to_replace))
         replace(path, to_find.upper(), to_replace.upper())
-    
+
     replace("./CMakeLists.txt", to_find, to_replace)
     replace("./Makefile", to_find, to_replace)
     replace("./Makefile", to_find.capitalize(), to_camel_case(to_replace))
@@ -59,20 +40,54 @@ def replace_everywhere(to_find, to_replace):
     replace("./README.md", to_find, to_replace)
     replace("./extension_config.cmake", to_find, to_replace)
 
-replace_everywhere("quack", name_extension)
-replace_everywhere("Quack", name_extension.capitalize())
-replace_everywhere("<extension_name>", name_extension)
 
-string_to_replace = name_extension
-string_to_find = "quack"
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise Exception(
+            "usage: python3 bootstrap-template.py <name_for_extension_in_snake_case>"
+        )
 
-# rename files
-os.rename(f'test/sql/{string_to_find}.test', f'test/sql/{string_to_replace}.test')
-os.rename(f'src/{string_to_find}_extension.cpp', f'src/{string_to_replace}_extension.cpp')
-os.rename(f'src/include/{string_to_find}_extension.hpp', f'src/include/{string_to_replace}_extension.hpp')
+    name_extension = sys.argv[1]
 
-# remove template-specific files
-os.remove('.github/workflows/ExtensionTemplate.yml')
+    if name_extension[0].isdigit():
+        raise Exception("Please dont start your extension name with a number.")
 
-# finally, remove this bootstrap file
-os.remove(__file__)
+    if not is_snake_case(name_extension):
+        raise Exception(
+            "Please enter the name of your extension in valid snake_case containing only lower case letters and numbers"
+        )
+
+    shutil.copyfile("docs/NEXT_README.md", "README.md")
+    os.remove("docs/NEXT_README.md")
+    os.remove("docs/README.md")
+
+    files_to_search = []
+    files_to_search.extend(Path("./.github").rglob("./**/*.yml"))
+    files_to_search.extend(Path("./test").rglob("./**/*.test"))
+    files_to_search.extend(Path("./src").rglob("./**/*.hpp"))
+    files_to_search.extend(Path("./src").rglob("./**/*.cpp"))
+    files_to_search.extend(Path("./src").rglob("./**/*.txt"))
+    files_to_search.extend(Path("./src").rglob("./*.md"))
+
+    replace_everywhere("quack", name_extension)
+    replace_everywhere("Quack", name_extension.capitalize())
+    replace_everywhere("<extension_name>", name_extension)
+
+    string_to_replace = name_extension
+    string_to_find = "quack"
+
+    # rename files
+    os.rename(f"test/sql/{string_to_find}.test", f"test/sql/{string_to_replace}.test")
+    os.rename(
+        f"src/{string_to_find}_extension.cpp", f"src/{string_to_replace}_extension.cpp"
+    )
+    os.rename(
+        f"src/include/{string_to_find}_extension.hpp",
+        f"src/include/{string_to_replace}_extension.hpp",
+    )
+
+    # remove template-specific files
+    os.remove(".github/workflows/ExtensionTemplate.yml")
+
+    # finally, remove this bootstrap file
+    os.remove(__file__)


### PR DESCRIPTION
Right now if you enter a bad name initially, you get stuck in a bad state because some of the file updates happen _before_ the name is checked. This PR reorgs the script so that it's generally organized more like a standard python script, but also moves the name validation before the rest of the script so it's less likely an extension creator gets into a bad state.