### PR TITLE
add custom toolchain script template

### DIFF
--- a/scripts/bootstrap-template.py
+++ b/scripts/bootstrap-template.py
@@ -39,6 +39,7 @@ def replace_everywhere(to_find, to_replace):
     replace("./Makefile", to_find.upper(), to_replace.upper())
     replace("./README.md", to_find, to_replace)
     replace("./extension_config.cmake", to_find, to_replace)
+    replace("./scripts/setup-custom-toolchain.sh", to_find, to_replace)
 
 
 if __name__ == "__main__":

--- a/scripts/setup-custom-toolchain.sh
+++ b/scripts/setup-custom-toolchain.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This is an example script that can be used to install additional toolchain dependencies. Feel free to remove this script
+# if no additional toolchains are required
+
+# To enable this script, set the `custom_toolchain_script` option to true when calling the reusable workflow
+# `.github/workflows/_extension_distribution.yml` from `https://github.com/duckdb/extension-ci-tools`
+
+# note that the $DUCKDB_PLATFORM environment variable can be used to discern between the platforms
+echo "This is the sample custom toolchain script running for architecture '$DUCKDB_PLATFORM' for the quack extension."
+


### PR DESCRIPTION
Related to https://github.com/duckdb/community-extensions/issues/73. We're adding a way for users to add some additional toolchain setup while still being able to use the toolchain from https://github.com/duckdb/extension-ci-tools.

This PR does not really do anything by itself but it will be used to:
- test the custom bootstrap script in CI of https://github.com/duckdb/extension-ci-tools
- demonstrate to new extension devs how to extend the default toolchain

Note that the custom toolchain script is not run by default by DuckDB, it needs to be explicitly enabled in the workflow as is explained in a comment in the sample script.