### PR TITLE
Build also against main, and fix test

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -12,6 +12,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  duckdb-next-build:
+    name: Build extension binaries
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    with:
+      duckdb_version: main
+      extension_name: quack
+
   duckdb-stable-build:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0

--- a/test/sql/quack.test
+++ b/test/sql/quack.test
@@ -18,6 +18,6 @@ SELECT quack('Sam');
 Quack Sam 🐥
 
 query I
-SELECT quack_openssl_version('Michael');
+SELECT quack_openssl_version('Michael') ILIKE 'Quack Michael, my linked OpenSSL version is OpenSSL%';
 ----
-<REGEX>:Quack Michael, my linked OpenSSL version is OpenSSL.*
+true


### PR DESCRIPTION
REGEXes are not properly supported on duckdb main on positive results, so working around that by reworking the test.

Mainly this PR adds testing both vs stable and vs main.