### PR TITLE
Add SQL scalar and table macros and tests

### DIFF
--- a/src/quack_extension.cpp
+++ b/src/quack_extension.cpp
@@ -7,11 +7,61 @@
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension_util.hpp"
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
+#include "duckdb/catalog/default/default_functions.hpp"
+#include "duckdb/catalog/default/default_table_functions.hpp"
 
 // OpenSSL linked through vcpkg
 #include <openssl/opensslv.h>
 
 namespace duckdb {
+
+
+// To add a new scalar SQL macro, add a new macro to this array!
+// Copy and paste the top item in the array into the 
+// second-to-last position and make some modifications. 
+// (essentially, leave the last entry in the array as {nullptr, nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr} )
+
+// Keep the DEFAULT_SCHEMA (no change needed)
+// Replace "times_two" with a name for your macro
+// If your function has parameters without default values, add their names in quotes inside of the {}, with a nullptr at the end
+//      If you do not have parameters, simplify to {nullptr}
+// If your function has parameters with default values, add their names and values in double quotes inside of {}'s inside of the {}.
+//      If you have default values that are strings, wrap them in single quotes inside the double quotes 
+//          (Ex: {{"my_string":"'my_default_value'"}, {nullptr, nullptr}} )
+//      Be sure to keep {nullptr, nullptr} at the end
+//      If you do not have parameters with default values, simplify to {nullptr, nullptr}
+// Add the text of your SQL macro as a raw string with the format R"( select 42 )"
+// clang-format off
+static DefaultMacro quack_macros[] = {
+    {DEFAULT_SCHEMA, "times_two", {"x", nullptr}, {{nullptr, nullptr}}, R"( x * 2 )"},
+    {DEFAULT_SCHEMA, "default_to_times_two", {"x", nullptr}, {{"multiplier", "2"}, {nullptr, nullptr}}, R"( x * multiplier )"},
+    {nullptr, nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr}
+};
+// clang-format on
+
+// To add a new SQL table macro, add a new macro to this array!
+// Copy and paste the top item in the array into the 
+// second-to-last position and make some modifications. 
+// (essentially, leave the last entry in the array as {nullptr, nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr}
+
+// Keep the DEFAULT_SCHEMA (no change needed)
+// Replace "times_two_table" with a name for your macro
+// If your function has parameters without default values, add their names in quotes inside of the {}, with a nullptr at the end
+//      If you do not have parameters, simplify to {nullptr}
+// If your function has parameters with default values, add their names and values in double quotes inside of {}'s inside of the {}.
+//      If you have default values that are strings, wrap them in single quotes inside the double quotes 
+//          (Ex: {{"my_string":"'my_default_value'"}, {nullptr, nullptr}} )
+//      Be sure to keep {nullptr, nullptr} at the end
+//      If you do not have parameters with default values, simplify to {nullptr, nullptr}
+// Add the text of your SQL macro as a raw string with the format R"( select 42; )" 
+
+// clang-format off 
+static const DefaultTableMacro quack_table_macros[] = {
+    {DEFAULT_SCHEMA, "times_two_table", {"x", nullptr}, {{nullptr, nullptr}},  R"( SELECT x * 2 as output_column; )"},
+    {DEFAULT_SCHEMA, "default_to_times_two_table", {"x", nullptr}, {{"multiplier", "2"}, {nullptr, nullptr}},  R"( SELECT x * multiplier as output_column; )"},
+	{nullptr, nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr}
+};
+// clang-format on
 
 inline void QuackScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &name_vector = args.data[0];
@@ -34,6 +84,17 @@ inline void QuackOpenSSLVersionScalarFun(DataChunk &args, ExpressionState &state
 }
 
 static void LoadInternal(DatabaseInstance &instance) {
+    // Register Scalar Macros
+	for (idx_t index = 0; quack_macros[index].name != nullptr; index++) {
+		auto info = DefaultFunctionGenerator::CreateInternalMacroInfo(quack_macros[index]);
+		ExtensionUtil::RegisterFunction(instance, *info);
+	}
+    // Register Table Macros
+    for (idx_t index = 0; quack_table_macros[index].name != nullptr; index++) {
+		auto table_info = DefaultTableFunctionGenerator::CreateTableMacroInfo(quack_table_macros[index]);
+        ExtensionUtil::RegisterFunction(instance, *table_info);
+	}
+    
     // Register a scalar function
     auto quack_scalar_function = ScalarFunction("quack", {LogicalType::VARCHAR}, LogicalType::VARCHAR, QuackScalarFun);
     ExtensionUtil::RegisterFunction(instance, quack_scalar_function);

--- a/test/sql/quack.test
+++ b/test/sql/quack.test
@@ -12,11 +12,49 @@ Catalog Error: Scalar Function with name quack does not exist!
 require quack
 
 # Confirm the extension works
+# Test scalar macro
+query I
+SELECT times_two(4);
+----
+8
+
+# Test table macro
+query I
+SELECT * FROM times_two_table(5);
+----
+10
+
+# Test scalar macro using a default
+query I
+SELECT default_to_times_two(4);
+----
+8
+
+# Test scalar macro overriding the default
+query I
+SELECT default_to_times_two(4, multiplier:=3);
+----
+12
+
+# Test table macro using a default
+query I
+SELECT * FROM default_to_times_two_table(5);
+----
+10
+
+# Test table macro overriding the default
+query I
+SELECT * FROM default_to_times_two_table(5, multiplier:=3);
+----
+15
+
+# Test scalar C++ function
 query I
 SELECT quack('Sam');
 ----
 Quack Sam 🐥
 
+# Test scalar C++ function using vcpkg and openssl
 query I
 SELECT quack_openssl_version('Michael') ILIKE 'Quack Michael, my linked OpenSSL version is OpenSSL%';
 ----


### PR DESCRIPTION
Hi folks! 

This adds support for SQL scalar and table macros to the extension template. 

I am super open to feedback - I added a big comment block within the .cpp file since our audience for this are SQL folks without C++ knowledge. If you would prefer to see it in a README or elsewhere, just let me know and I can move/adjust.

The goal is to publish the SQL-only extension blog post that relies on this feature by this Friday, 2024-09-20, but I don't think we have anything on the blog schedule for the following week. I am flexible!

@szarnyasg as an FYI since this is related to the upcoming blog!