### PR TITLE
Replace distribution extension yaml

### DIFF
--- a/scripts/bootstrap-template.py
+++ b/scripts/bootstrap-template.py
@@ -104,6 +104,7 @@ def replace_everywhere(to_find: str, to_replace: str) -> None:
     replace("./README.md", to_find, to_replace)
     replace("./extension_config.cmake", to_find, to_replace)
     replace("./scripts/setup-custom-toolchain.sh", to_find, to_replace)
+    replace(".github/workflows/MainDistributionPipeline.yml", to_find, to_replace)
 
 
 def remove_placeholder() -> None:


### PR DESCRIPTION
When I ran bootstrap script `python3 bootstrap-template.py <name_for_extension_in_snake_case>` to setup and initialize the extension repository, I found extension name within distribution pipeline is not updated accordingly, which leads to CI (in my own repo failure).

![image](https://github.com/user-attachments/assets/8e0dbf7b-52e8-42a2-bba5-47ce349db7d9)
