### PR TITLE
Update description on how to activate the custom-toolchain-script

### DIFF
--- a/scripts/setup-custom-toolchain.sh
+++ b/scripts/setup-custom-toolchain.sh
@@ -3,8 +3,9 @@
 # This is an example script that can be used to install additional toolchain dependencies. Feel free to remove this script
 # if no additional toolchains are required
 
-# To enable this script, set the `custom_toolchain_script` option to true when calling the reusable workflow
-# `.github/workflows/_extension_distribution.yml` from `https://github.com/duckdb/extension-ci-tools`
+# To use this script in the GitHub Actions setup, override the `configure_ci` target in your Makefile
+# and have it call this script.
+# Example: `bash ./scripts/setup-custom-toolchain.sh`
 
 # note that the $DUCKDB_PLATFORM environment variable can be used to discern between the platforms
 echo "This is the sample custom toolchain script running for architecture '$DUCKDB_PLATFORM' for the quack extension."


### PR DESCRIPTION
Hey DuckDB team!

I recently started using your extension template, and had to bump the versions of the submodules referencing `DuckDB` and the `extension-ci-tools` to v1.2. I noticed that the CI/CD Github actions previously had a flag that would activate the use of `scripts/install-custom-toolchain.sh`, but now it is changed so that we would have to override the `configure_ci` target in the Makefile. 

So I have update the description inside the script😄 