### PR TITLE
Move to extension-ci-tools provided vcpkg_ports

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,16 +1,10 @@
 {
-  "dependencies": [
-    "openssl"
-  ],
-  "vcpkg-configuration": {
-		"registries": [
-			{
-				"kind": "git",
-				"repository": "https://github.com/duckdb/vcpkg-duckdb-ports",
-				"baseline": "0f9bf648ba1ee29291890a1ca9a49a80bba017eb",
-				"packages": ["vcpkg-cmake"]
-			}
-		]
-	},
-  "builtin-baseline" : "5e5d0e1cd7785623065e77eff011afdeec1a3574"
+        "dependencies": [
+                "openssl"
+        ],
+        "vcpkg-configuration": {
+                "overlay-ports": [
+                        "./extension-ci-tools/vcpkg_ports"
+                ]
+        }
 }


### PR DESCRIPTION
This cuts in complexity AND maintenance cost for extension developers, back to having no hardcoded version in the template, and inheriting them explicit through `extension-ci-tools` or `duckdb`.

See context at https://github.com/duckdb/extension-ci-tools/issues/176