### PR TITLE
Skip building vs main

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -15,6 +15,7 @@ jobs:
   duckdb-next-build:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    if: false   # extension-template is currently not compatible with main
     with:
       duckdb_version: main
       ci_tools_version: main
@@ -32,7 +33,7 @@ jobs:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
     with:
-      duckdb_version: main
+      duckdb_version: v1.3.0
       ci_tools_version: main
       extension_name: quack
       format_checks: 'format;tidy'


### PR DESCRIPTION
Currently extension-template is not compatible with duckdb/duckdb main, to be adapted and re-enabled.