### PR TITLE
fix CI malformed in recent merge

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -12,18 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  duckdb-next-build:
-    name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
-    with:
-      duckdb_version: v1.4.0
-      extension_name: quack
-      ci_tools_version: main
-
   duckdb-stable-build:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.0
-    if: false # This branch is not compatible with latest stable, TODO: remove when merging this branch back into main
     with:
       duckdb_version: v1.4.0
       ci_tools_version: v1.4.0

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -22,9 +22,9 @@ jobs:
 
   code-quality-check:
     name: Code Quality Check
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.4.0
     with:
-      duckdb_version: main # TODO: revert to latest stable probably
-      ci_tools_version: main
+      duckdb_version: v1.4.0
+      ci_tools_version: v1.4.0
       extension_name: quack
       format_checks: 'format;tidy'


### PR DESCRIPTION
@carlopi i've also just removed the next_build CI for now. i feel it's just a little too heavy to just run on every PR/push. The recommended way should be to run this on a separate branch and modify the distribution of that branch, agreed?