### PR TITLE
ci: Skip CI for version bump commits

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -15,6 +15,7 @@ jobs:
   duckdb-stable-build:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.3
+    if: (github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI] bump to')) && (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI] bump to'))
     with:
       duckdb_version: v1.4.3
       ci_tools_version: v1.4.3
@@ -23,6 +24,7 @@ jobs:
   code-quality-check:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.4.3
+    if: (github.event_name != 'push' || !contains(join(github.event.commits.*.message, ' '), '[SKIP_CI] bump to')) && (github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[SKIP_CI] bump to'))
     with:
       duckdb_version: v1.4.3
       ci_tools_version: v1.4.3


### PR DESCRIPTION
This PR adds a conditional skip to the CI workflow to avoid running builds and tests when the commit message or PR title contains the explicit pattern: `[SKIP_CI] bump to`.