### PR TITLE
Remove `LOAD_TESTS` from extension load

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,6 @@
 # Extension from this repo
 duckdb_extension_load(quack
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    LOAD_TESTS
 )
 
 # Any extra extensions that should be built


### PR DESCRIPTION
This is no longer required - the unittest runner automatically sets the test directory to the extension root, so all tests in `test` are automatically added. Adding `LOAD_TESTS` adds the tests twice.