### PR TITLE
Bump extension template to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
+
+set(CMAKE_CXX_STANDARD "17" CACHE STRING "C++ standard to enforce")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 include_directories(src/include)
 
 set(EXTENSION_SOURCES src/quack_extension.cpp)


### PR DESCRIPTION
Since DuckDB is going to be using C++17, the extension template should as well.