### PR TITLE
Fix VCPKG_TOOLCHAIN_PATH path in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ cd <your-working-dir-not-the-plugin-repo>
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg && git checkout ce613c41372b23b1f51333815feb3edd87ef8a8b
 sh ./scripts/bootstrap.sh -disableMetrics
-export VCPKG_TOOLCHAIN_PATH=`pwd`/vcpkg/scripts/buildsystems/vcpkg.cmake
+export VCPKG_TOOLCHAIN_PATH=`pwd`/scripts/buildsystems/vcpkg.cmake
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Updated the VCPKG_TOOLCHAIN_PATH export command in README.